### PR TITLE
Fix ROSCO version number in ROSCO_Types.f90

### DIFF
--- a/rosco/controller/src/ROSCO_Types.f90
+++ b/rosco/controller/src/ROSCO_Types.f90
@@ -7,7 +7,7 @@ USE, INTRINSIC :: ISO_C_Binding
 USE Constants
 IMPLICIT NONE
 
-Character(*), PARAMETER     :: rosco_version = '2.10.1'             ! ROSCO version
+Character(*), PARAMETER     :: rosco_version = '2.10.5'             ! ROSCO version
 
 TYPE, PUBLIC :: ControlParameters
     INTEGER(IntKi)                :: ZMQ_ID                      ! 0000 - 9999, Identifier of the rosco, used for zeromq interface only


### PR DESCRIPTION
Corrected the ROSCO version number in ROSCO_Types.f90 to match the current release.

## Description and Purpose
This PR updates the ROSCO version number in `ROSCO_Types.f90` to ensure consistency with the current ROSCO release.

## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Github issues addressed, if one exists
N/A

## Examples/Testing, if applicable
No functional changes. No additional testing required.

